### PR TITLE
Fix "_FirebaseAnalyticsSDKBaseFolder" path

### DIFF
--- a/source/Firebase/Analytics/Analytics.targets
+++ b/source/Firebase/Analytics/Analytics.targets
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<PropertyGroup>
 		<_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
 		<_FirebaseAnalyticsItemsFolder>FAnlytcs-8.2.0</_FirebaseAnalyticsItemsFolder>
-		<_FirebaseAnalyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseAnalyticsItemsFolder)\FirebaseAnalytics-8.0.0\Frameworks\</_FirebaseAnalyticsSDKBaseFolder>
+		<_FirebaseAnalyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseAnalyticsItemsFolder)\FirebaseAnalytics-8.1.1\Frameworks\</_FirebaseAnalyticsSDKBaseFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">


### PR DESCRIPTION
Otherwise client builds fail because they can't find the `xcframework`.